### PR TITLE
Update action.py: correct docker kill signal option case

### DIFF
--- a/app/modules/service/action.py
+++ b/app/modules/service/action.py
@@ -56,7 +56,7 @@ def get_action_command(service: str, action: str, server_id: int) -> str:
     if is_docker == '1':
         container_name = sql.get_setting(f'{service}_container_name')
         if action == 'reload':
-            action = 'kill -S HUP'
+            action = 'kill -s HUP'
         commands = f"sudo docker {action} {container_name}"
     else:
         service_name = service_common.get_correct_service_name(service, server_id)


### PR DESCRIPTION
Previously, when handling the reload action, the code used `docker kill -S HUP`. However, the Docker CLI only supports the lowercase `-s` option. Using `-S` results in an error and prevents the signal from being sent to the container process.

This change:
- Corrects `kill -S HUP` to `kill -s HUP`
- Ensures that in Docker mode, the reload action can properly send the SIGHUP signal
- Keeps the systemd branch logic unchanged